### PR TITLE
Updated the pool test cases for testing '/' in poolname

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
@@ -37,11 +37,18 @@ POOL2_INCLUDE_DEFERRED = False
 POOL2_DESCRIPTION = "Some Description"
 
 
+POOL3_NAME = "pool/3"
+POOL3_SLOT = 5
+POOL3_INCLUDE_DEFERRED = False
+POOL3_DESCRIPTION = "Some Description"
+
+
 @provide_session
 def _create_pools(session) -> None:
     pool1 = Pool(pool=POOL1_NAME, slots=POOL1_SLOT, include_deferred=POOL1_INCLUDE_DEFERRED)
     pool2 = Pool(pool=POOL2_NAME, slots=POOL2_SLOT, include_deferred=POOL2_INCLUDE_DEFERRED)
-    session.add_all([pool1, pool2])
+    pool3 = Pool(pool=POOL3_NAME, slots=POOL3_SLOT, include_deferred=POOL3_INCLUDE_DEFERRED, description=POOL3_DESCRIPTION)
+    session.add_all([pool1, pool2, pool3])
 
 
 class TestPoolsEndpoint:
@@ -60,11 +67,11 @@ class TestDeletePool(TestPoolsEndpoint):
     def test_delete_should_respond_204(self, test_client, session):
         self.create_pools()
         pools = session.query(Pool).all()
-        assert len(pools) == 3
+        assert len(pools) == 4
         response = test_client.delete(f"/pools/{POOL1_NAME}")
         assert response.status_code == 204
         pools = session.query(Pool).all()
-        assert len(pools) == 2
+        assert len(pools) == 3
         check_last_log(session, dag_id=None, event="delete_pool", logical_date=None)
 
     def test_delete_should_respond_401(self, unauthenticated_test_client):
@@ -86,6 +93,17 @@ class TestDeletePool(TestPoolsEndpoint):
         assert response.status_code == 404
         body = response.json()
         assert f"The Pool with name: `{POOL1_NAME}` was not found" == body["detail"]
+
+    def test_delete_pool3_should_respond_204(self, test_client, session):
+        """Test deleting POOL3 with forward slash in name"""
+        self.create_pools()
+        pools = session.query(Pool).all()
+        assert len(pools) == 4
+        response = test_client.delete(f"/pools/{POOL3_NAME}")
+        assert response.status_code == 204
+        pools = session.query(Pool).all()
+        assert len(pools) == 3
+        check_last_log(session, dag_id=None, event="delete_pool", logical_date=None)
 
 
 class TestGetPool(TestPoolsEndpoint):
@@ -120,24 +138,42 @@ class TestGetPool(TestPoolsEndpoint):
         body = response.json()
         assert f"The Pool with name: `{POOL1_NAME}` was not found" == body["detail"]
 
+    def test_get_pool3_should_respond_200(self, test_client, session):
+        """Test getting POOL3 with forward slash in name"""
+        self.create_pools()
+        response = test_client.get(f"/pools/{POOL3_NAME}")
+        assert response.status_code == 200
+        assert response.json() == {
+            "deferred_slots": 0,
+            "description": "Some Description",
+            "include_deferred": False,
+            "name": "pool/3",
+            "occupied_slots": 0,
+            "open_slots": 5,
+            "queued_slots": 0,
+            "running_slots": 0,
+            "scheduled_slots": 0,
+            "slots": 5,
+        }
+
 
 class TestGetPools(TestPoolsEndpoint):
     @pytest.mark.parametrize(
         "query_params, expected_total_entries, expected_ids",
         [
             # Filters
-            ({}, 3, [Pool.DEFAULT_POOL_NAME, POOL1_NAME, POOL2_NAME]),
-            ({"limit": 1}, 3, [Pool.DEFAULT_POOL_NAME]),
-            ({"limit": 1, "offset": 1}, 3, [POOL1_NAME]),
+            ({}, 4, [Pool.DEFAULT_POOL_NAME, POOL1_NAME, POOL2_NAME, POOL3_NAME]),
+            ({"limit": 1}, 4, [Pool.DEFAULT_POOL_NAME]),
+            ({"limit": 1, "offset": 1}, 4, [POOL1_NAME]),
             # Sort
-            ({"order_by": "-id"}, 3, [POOL2_NAME, POOL1_NAME, Pool.DEFAULT_POOL_NAME]),
-            ({"order_by": "id"}, 3, [Pool.DEFAULT_POOL_NAME, POOL1_NAME, POOL2_NAME]),
-            ({"order_by": "name"}, 3, [Pool.DEFAULT_POOL_NAME, POOL1_NAME, POOL2_NAME]),
+            ({"order_by": "-id"}, 4, [POOL3_NAME, POOL2_NAME, POOL1_NAME, Pool.DEFAULT_POOL_NAME]),
+            ({"order_by": "id"}, 4, [Pool.DEFAULT_POOL_NAME, POOL1_NAME, POOL2_NAME, POOL3_NAME]),
+            ({"order_by": "name"}, 4, [Pool.DEFAULT_POOL_NAME, POOL3_NAME, POOL1_NAME, POOL2_NAME]),
             # Search
             (
                 {"pool_name_pattern": "~"},
-                3,
-                [Pool.DEFAULT_POOL_NAME, POOL1_NAME, POOL2_NAME],
+                4,
+                [Pool.DEFAULT_POOL_NAME, POOL1_NAME, POOL2_NAME, POOL3_NAME],
             ),
             ({"pool_name_pattern": "default"}, 1, [Pool.DEFAULT_POOL_NAME]),
         ],
@@ -313,6 +349,32 @@ class TestPatchPool(TestPoolsEndpoint):
     def test_should_respond_403(self, unauthorized_test_client):
         response = unauthorized_test_client.patch(f"/pools/{POOL1_NAME}", params={}, json={})
         assert response.status_code == 403
+
+    def test_patch_pool3_should_respond_200(self, test_client, session):
+        """Test patching POOL3 with forward slash in name"""
+        self.create_pools()
+        body = {
+            "slots": 10,
+            "description": "Updated Description",
+            "name": POOL3_NAME,
+            "include_deferred": True,
+        }
+        response = test_client.patch(f"/pools/{POOL3_NAME}", json=body)
+        assert response.status_code == 200
+        expected_response = {
+            "deferred_slots": 0,
+            "description": "Updated Description",
+            "include_deferred": True,
+            "name": "pool/3",
+            "occupied_slots": 0,
+            "open_slots": 10,
+            "queued_slots": 0,
+            "running_slots": 0,
+            "scheduled_slots": 0,
+            "slots": 10,
+        }
+        assert response.json() == expected_response
+        check_last_log(session, dag_id=None, event="patch_pool", logical_date=None)
 
 
 class TestPostPool(TestPoolsEndpoint):


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
