### PR TITLE
Fix pool ordering test inconsistency across environments

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
@@ -37,7 +37,7 @@ POOL2_INCLUDE_DEFERRED = False
 POOL2_DESCRIPTION = "Some Description"
 
 
-POOL3_NAME = "pool/3"
+POOL3_NAME = "pool3/with_slashes"
 POOL3_SLOT = 5
 POOL3_INCLUDE_DEFERRED = False
 POOL3_DESCRIPTION = "Some Description"
@@ -152,7 +152,7 @@ class TestGetPool(TestPoolsEndpoint):
             "deferred_slots": 0,
             "description": "Some Description",
             "include_deferred": False,
-            "name": "pool/3",
+            "name": "pool3/with_slashes",
             "occupied_slots": 0,
             "open_slots": 5,
             "queued_slots": 0,
@@ -173,7 +173,7 @@ class TestGetPools(TestPoolsEndpoint):
             # Sort
             ({"order_by": "-id"}, 4, [POOL3_NAME, POOL2_NAME, POOL1_NAME, Pool.DEFAULT_POOL_NAME]),
             ({"order_by": "id"}, 4, [Pool.DEFAULT_POOL_NAME, POOL1_NAME, POOL2_NAME, POOL3_NAME]),
-            ({"order_by": "name"}, 4, [Pool.DEFAULT_POOL_NAME, POOL3_NAME, POOL1_NAME, POOL2_NAME]),
+            ({"order_by": "name"}, 4, [Pool.DEFAULT_POOL_NAME, POOL1_NAME, POOL2_NAME, POOL3_NAME]),
             # Search
             (
                 {"pool_name_pattern": "~"},
@@ -370,7 +370,7 @@ class TestPatchPool(TestPoolsEndpoint):
             "deferred_slots": 0,
             "description": "Updated Description",
             "include_deferred": True,
-            "name": "pool/3",
+            "name": "pool3/with_slashes",
             "occupied_slots": 0,
             "open_slots": 10,
             "queued_slots": 0,


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
